### PR TITLE
Guard registration deletion behind a per-form opt-in setting

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -294,6 +294,7 @@ class Admin
         $recaptchaSiteKey    = get_post_meta($post->ID, '_rfmp_recaptcha_v3_site_key', true);
         $recaptchaSecretKey  = get_post_meta($post->ID, '_rfmp_recaptcha_v3_secret_key', true);
         $recaptchaScore      = get_post_meta($post->ID, '_rfmp_recaptcha_v3_minimum_score', true) ?: MollieForms::DEFAULT_MINIMUM_RECAPTCHA_SCORE;
+        $allowDeletion       = get_post_meta($post->ID, '_rfmp_allow_deletion', true) ?: 'no';
 
         include $this->mollieForms->getDirPath() . 'templates/metaboxes/settings.php';
     }
@@ -489,6 +490,7 @@ class Admin
         update_post_meta($postId, '_rfmp_recaptcha_v3_site_key', sanitize_text_field($_POST['rfmp_recaptcha_v3_site_key']));
         update_post_meta($postId, '_rfmp_recaptcha_v3_secret_key', sanitize_text_field($_POST['rfmp_recaptcha_v3_secret_key']));
         update_post_meta($postId, '_rfmp_recaptcha_v3_minimum_score', sanitize_text_field($_POST['rfmp_recaptcha_v3_minimum_score']));
+        update_post_meta($postId, '_rfmp_allow_deletion', (isset($_POST['rfmp_allow_deletion']) && $_POST['rfmp_allow_deletion'] === 'yes') ? 'yes' : 'no');
 
         // Add address fields when API type is "orders"
         if ($_POST['rfmp_api_type'] == 'orders') {
@@ -681,6 +683,10 @@ class Admin
                     $msg = '<div class="updated notice"><p>' .
                            esc_html__('The registration is successful deleted', 'mollie-forms') . '</p></div>';
                     break;
+                case 'delete-not-allowed':
+                    $msg = '<div class="error notice"><p>' .
+                           esc_html__('Deletion is not authorised for this form. Enable it in the form settings first.', 'mollie-forms') . '</p></div>';
+                    break;
             }
 
             echo esc_html($msg ?? '');
@@ -730,6 +736,12 @@ class Admin
 
         // Delete registration
         if (isset($_GET['delete']) && check_admin_referer('delete-reg_' . $id)) {
+            // Deletion must be explicitly authorised on the form, otherwise refuse.
+            if (get_post_meta($registration->post_id, '_rfmp_allow_deletion', true) !== 'yes') {
+                wp_redirect('?post_type=mollie-forms&page=registrations&msg=delete-not-allowed');
+                exit;
+            }
+
             $this->db->delete($this->mollieForms->getRegistrationsTable(), [
                     'id' => $id,
             ]);

--- a/classes/RegistrationsTable.php
+++ b/classes/RegistrationsTable.php
@@ -46,12 +46,18 @@ class RegistrationsTable extends \WP_List_Table
      */
     function column_actions($item)
     {
-        $url_view   = 'edit.php?post_type=mollie-forms&page=registration&view=' . $item['id'];
+        $url_view = 'edit.php?post_type=mollie-forms&page=registration&view=' . $item['id'];
+        $view     = sprintf('<a href="%s">' . esc_html__('View', 'mollie-forms') . '</a>', esc_url($url_view));
+
+        // Only offer deletion when the form explicitly authorises it.
+        if (get_post_meta($item['post_id'], '_rfmp_allow_deletion', true) !== 'yes') {
+            return $view;
+        }
+
         $url_delete = wp_nonce_url('edit.php?post_type=mollie-forms&page=registration&view=' . $item['id'] . '&delete=true', 'delete-reg_' . $item['id']);
-        return sprintf('<a href="%s">' . esc_html__('View', 'mollie-forms') .
-                       '</a> <a href="%s" style="color:#a00;" onclick="return confirm(\'' .
+        return sprintf('%s <a href="%s" style="color:#a00;" onclick="return confirm(\'' .
                        esc_html__('Are you sure?', 'mollie-forms') . '\');">' . esc_html__('Delete', 'mollie-forms') .
-                       '</a>', $url_view, $url_delete);
+                       '</a>', $view, $url_delete);
     }
 
     /**

--- a/includes/js/admin-scripts.js
+++ b/includes/js/admin-scripts.js
@@ -66,6 +66,17 @@ jQuery(document).ready(function($) {
         }
     });
 
+    $("body").on('change', '[name=rfmp_allow_deletion]', function() {
+        if ($(this).val() == 'yes')
+        {
+            $('.rfmp_allow_deletion_warning').show();
+        }
+        else
+        {
+            $('.rfmp_allow_deletion_warning').hide();
+        }
+    });
+
     $("body").on('change', '.rfmp_type', function() {
         var $value = $(this).closest('td').next('td').next('td').find(".rfmp_value");
         if ($(this).val() == 'dropdown' || $(this).val() == 'radio') {

--- a/templates/metaboxes/settings.php
+++ b/templates/metaboxes/settings.php
@@ -242,6 +242,25 @@
             </td>
         </tr>
 
+        <tr valign="top">
+            <th scope="row" class="titledesc">
+                <label for="rfmp_allow_deletion"><?php esc_html_e('Authorise deletion of rows', 'mollie-forms');?></label>
+            </th>
+            <td class="forminp forminp-text">
+                <select name="rfmp_allow_deletion" id="rfmp_allow_deletion" style="width: 350px;">
+                    <option value="no"><?php esc_html_e('No', 'mollie-forms');?></option>
+                    <option value="yes"<?php echo ($allowDeletion == 'yes' ? ' selected' : '');?>><?php esc_html_e('Yes', 'mollie-forms');?></option>
+                </select>
+                <br><small><?php esc_html_e('Allows deleting registrations from the entries overview. Disabled by default.', 'mollie-forms');?></small>
+                <div class="rfmp_allow_deletion_warning notice notice-warning inline" style="margin: 8px 0 0; padding: 8px 12px;<?php echo ($allowDeletion == 'yes' ? '' : ' display: none;');?>">
+                    <p style="margin: 0;">
+                        <strong><?php esc_html_e('Warning:', 'mollie-forms');?></strong>
+                        <?php esc_html_e('Deleting registrations is not recommended. It creates gaps in your payment IDs and permanently removes payment records. Only enable this if you are certain you need it.', 'mollie-forms');?>
+                    </p>
+                </div>
+            </td>
+        </tr>
+
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
Deleting registrations leaves gaps in payment IDs and permanently removes payment records, which is undesirable by default. This adds an "Authorise deletion of rows" setting to each form (below the reCAPTCHA settings), defaulting to "No".

- New per-form setting saved as `_rfmp_allow_deletion` (no/yes)
- Selecting "Yes" shows a warning that deletion is not best practice
- The Delete link in the entries overview only appears when the form has deletion authorised
- Server-side guard in the delete handler refuses deletion unless the form authorises it, so a hand-crafted URL cannot bypass the UI