### PR TITLE
Render admin registration notices as HTML instead of escaped text

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -683,7 +683,7 @@ class Admin
                     break;
             }
 
-            echo esc_html($msg ?? '');
+            echo wp_kses_post($msg ?? '');
         }
         ?>
         <div class="wrap">


### PR DESCRIPTION
## Summary

The registration deletion notice on the Registrations admin page was output with `esc_html()`, which escaped its own trusted wrapper markup. As a result the notice rendered as literal text (e.g. `<div class="updated notice"><p>...`) instead of a styled WordPress admin notice.

The message string is assembled internally from `esc_html__()`-escaped translations wrapped in known-safe markup, so `wp_kses_post()` is the appropriate output function — it preserves the safe notice HTML while still stripping anything unexpected.

## Change

`classes/Admin.php`:
```diff
-            echo esc_html($msg ?? '');
+            echo wp_kses_post($msg ?? '');
```

## Notes

This is a pre-existing bug, independent of the per-form deletion-authorisation feature. Submitting it separately to keep the changes unconfused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)